### PR TITLE
投稿編集機能実装

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -1,6 +1,6 @@
 class ContentsController < ApplicationController
   before_action :set_group
-  before_action :set_content, only: [:show, :edit, :update, :destroy]
+  before_action :set_content, only: [:show, :edit, :update, :destroy, :edit, :update]
 
   def index
     @content = Content.new
@@ -29,15 +29,30 @@ class ContentsController < ApplicationController
 
   def destroy
     if @content.destroy
-      redirect_to group_mypages_path, notice: '削除しました'
+      redirect_to group_mypages_path, notice: '削除できました'
     else
       render :show
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @content.update(update_content_params)
+      redirect_to group_contents_path(@group), notice: '変更できました'
+    else
+      render :edit
     end
   end
 
   private
 
   def content_params
+    params.require(:content).permit(:text, :title, :image).merge(user_id: current_user.id)
+  end
+
+  def update_content_params
     params.require(:content).permit(:text, :title, :image).merge(user_id: current_user.id)
   end
 

--- a/app/views/contents/edit.html.haml
+++ b/app/views/contents/edit.html.haml
@@ -1,0 +1,26 @@
+.wrapper
+  =render 'shared/header'
+  .form
+    .form-group
+      .form-title
+        投稿内容を入力
+      .form-contents
+        = form_with model:[@group,@content], local:true do |f|
+          .form__mask
+            -if @content.image.present?
+              = image_tag @content.image.to_s, id: 'img_prev'
+            -else
+              = image_tag "no_image.png", id: 'img_prev'
+            .uploadButton
+              ファイルを選択
+              = f.label :image, class: 'form__mask__image' do
+                = f.file_field :image, class: 'hidden-img', id: 'user_img'
+          .form-contents__title
+            タイトル
+            %br
+            = f.text_field :title, placeholder: 'タイトルを入力してください'
+          .form-contents__text
+            テキスト
+            %br
+            = f.text_area :text, placeholder: 'テキストを入力してください'
+          = f.submit '変更して一覧に戻る', class: 'form__submit'

--- a/app/views/contents/show.html.haml
+++ b/app/views/contents/show.html.haml
@@ -29,7 +29,7 @@
           %p
             = @content.text
     .content-left-btn-box
-      = link_to "編集する", "#", class: "content-edit-btn"
+      = link_to "編集する", edit_group_content_path(@content.group_id,@content.id), class: "content-edit-btn"
       = link_to "削除する", group_content_path(@content.group_id,@content.id), class: "content-delete-btn", method: :delete
     .content-right-btn-box
       = link_to "戻る", :back, class: "content-back-btn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
-    resources :contents, only: [:index, :new, :create, :show, :destroy]
+    resources :contents, only: [:index, :new, :create, :show, :destroy, :edit, :update]
     resources :mypages, only: [:index]
   end
 end


### PR DESCRIPTION
# What
投稿編集機能を実装した。

## 実装内容
### １．ルーティング，コントローラーにアクション追加
・edit,updateアクション
### ２．投稿編集ページマークアップ 
### ３．投稿詳細ページの「編集する」ボタンにパスを追加

# Why
投稿内容を修正したい時、削除→再投稿では時間がかかるため。

挙動確認GIF
https://i.gyazo.com/449a03896454c0f79c4ff8d87328bfa6.gif