### PR TITLE
グループ削除機能+ビュー微修正

### DIFF
--- a/app/assets/javascripts/delete.js
+++ b/app/assets/javascripts/delete.js
@@ -6,4 +6,10 @@ $(document).on('turbolinks:load', function(){
       return false;
     }
   });
+  $('.group-form__delete-btn').click(function(){
+    var alert = "削除すると２度と復活できません。\n削除前にグループメンバーに確認をお願いします。\n本当に削除しますか？"
+    if(!confirm(alert)){
+      return false;
+    }
+  });
 }); 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -57,11 +57,16 @@ $(function() {
   $(document).on("click", ".group-user__btn--add", function() {
     const userName = $(this).attr("data-user-name");
     const userId = $(this).attr("data-user-id");
+    var alert = "ユーザーの追加は相手に事前確認しておくことを推奨します\n「更新する」ボタンを押すと反映されます"
+    if(!confirm(alert)){
+      return false;
+    }
     $(this)
       .parent()
       .remove();
     addDeleteUser(userName, userId);
     addMember(userId);
+
   });
   $(document).on("click", ".group-user__btn--remove", function() {
     $(this)

--- a/app/assets/stylesheets/groups/_group.scss
+++ b/app/assets/stylesheets/groups/_group.scss
@@ -105,3 +105,13 @@ li {
     }
   }
 }
+
+.group-form__delete-btn {
+  padding: 12px 20px;
+  color: #fff;
+  background-color: #aaa;
+  border: 0;
+  position: relative;
+  top: -45px;
+  float: right;
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,6 +31,15 @@ class GroupsController < ApplicationController
     end
   end
 
+  def destroy
+    @group = Group.find(params[:id])
+    if @group.destroy
+      redirect_to root_path, notice: '削除できました'
+    else
+      render :edit
+    end
+  end
+
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [])

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  has_many :group_users
+  has_many :group_users, dependent: :destroy
   has_many :users, through: :group_users
   has_many :contents
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :group_users
+  has_many :group_users, dependent: :destroy
   has_many :groups, through: :group_users
   has_many :contents
   mount_uploader :image, ImageUploader

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -15,7 +15,7 @@
       %label.group-form__label{for: "group_グループメンバーを追加"} グループメンバーを追加
     .group-form__field--right
       .group-form__search.clearfix
-        %input#user-search-field.group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
+        %input#user-search-field.group-form__input{placeholder: "追加したいユーザー名を入力してください（任意）", type: "text"}/
       #user-search-result
 
   .group-form__field.clearfix
@@ -41,3 +41,4 @@
     .group-form__field--left
     .group-form__field--right
       = f.submit class: 'group-form__action-btn'
+

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,4 @@
 .group-form
   %h1 グループ編集
   = render partial: 'form', locals: { group: @group }
+  = link_to "このグループを削除する", group_path(@group), class: "group-form__delete-btn", method: :delete

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -22,10 +22,7 @@
             %h3
               = link_to "#" do
                 最近の投稿内容
-          %li
-            %h3
-              = link_to "#" do
-                お知らせ
+
         .mypage-tab-container__tab-content
           %ul.mypage-tab-container__tab-content__list
             - if @contents.present?

--- a/app/views/shared/_side-bar.html.haml
+++ b/app/views/shared/_side-bar.html.haml
@@ -15,19 +15,11 @@
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li
         = link_to edit_group_path(@group), data: { "turbolinks"=> false }, class: 'mypage-nav__list__item' do
-          グループ編集
+          グループ編集・削除
           = icon('fas', 'angle-right', class: 'mypage-style-right')
       %li
         = link_to groups_path, class: 'mypage-nav__list__item' do
           グループ切替え
-          = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to "#", class: 'mypage-nav__list__item' do
-          お知らせ(近日実装予定)
-          = icon('fas', 'angle-right', class: 'mypage-style-right')
-      %li
-        = link_to "#", class: 'mypage-nav__list__item' do
-          招待する(近日実装予定)
           = icon('fas', 'angle-right', class: 'mypage-style-right')
 
     %h3.mypage-nav__head 設定

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'groups#index'
 
   resources :users, only: [:index, :show, :edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update] do
+  resources :groups, only: [:index, :new, :create, :edit, :update, :destroy] do
     resources :contents, only: [:index, :new, :create, :show, :destroy, :edit, :update] do
       collection do
         get 'search'


### PR DESCRIPTION
# What
グループ削除機能の実装＋ビューの微修正を実施した。

## 実装内容
### １．ルーティング,コントローラにdestroyアクションを追加
### ２．group.rb,user.rb編集
・dependent: :destroyを追加
### ３．views/groups/edit.html.haml編集
・グループ削除ボタンを追加
### ４．delete.js追加
・グループ削除前のアラートを追加
### ５．user.js編集
・ユーザー追加時のアラートを追加
### ６．マイページのレイアウトを微修正

# Why
誤って作成したグループを削除できるようにするため。

GIF
https://i.gyazo.com/de5c026eef25d33188b9832f2088f1f6.gif

<img width="1434" alt="スクリーンショット 2020-05-30 18 56 28" src="https://user-images.githubusercontent.com/57065520/83325469-653dab80-a2a7-11ea-9181-e68d9d51a55b.png">
